### PR TITLE
Headless filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Several options may be configured globally per-app.
 
 | Property           | Type              | Default                | Description |
 |--------------------|-------------------|------------------------|-------------|
+|`filterFields`      |`string`           |`""`                    |A comma separated string that contains the names of the properties to which the filter will be applied.  _(This can be overridden per-table)_|
 |`filterTemplate`    |`string`           |`""`                    |HTML string template for filtering the table. _This will be included **before** the element with `ts-wrapper` specified on it._  See example above.|
 |`filterFunction`    |`function`         |`null`                  |A function that will be called for every item being iterated over in the table. This function will be passed the object being iterated over as the first parameter. It should return a `boolean` value as to include the item or not.  _(This can be overridden per-table)_|
 |`itemNameSingular`  |`string`           |`"item"`                |The default singular version of the name for the items being iterated over. _(This can be overridden per-table)_|
@@ -229,7 +230,9 @@ Changing the item name will also update the "no data" display to be `"No " +  IT
 
 ###Table Filtering & Pagination Usage
 
-To mark a column as filterable, add the `ts-filter` attribute to the `<th>` element.  The property specified in the `ts-criteria` attribute will be used to filter.
+There are a couple of ways to mark a column as filterable.
+
+One approach is to add the `ts-filter` attribute to the `<th>` element.  The property specified in the `ts-criteria` attribute will be used to filter.
 
  ```html
 <thead>
@@ -242,6 +245,12 @@ To mark a column as filterable, add the `ts-filter` attribute to the `<th>` elem
 </thead>
 ```
 **NOTE** that the `ts-filter` attribute is not needed if custom filtering using the `ts-filter-function` attribute.
+
+Another approach is to add the `ts-filter-fields` attribute to the same element as the `ts-wrapper`.  This attribute takes a comma separated list of all the fields to which the filter should be applied.
+
+```html
+<table ts-wrapper ts-filter-fields="Name,Price,Quantity">
+```
 
 ####Customized Pagination Options
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Several options may be configured globally per-app.
 
 | Property           | Type              | Default                | Description |
 |--------------------|-------------------|------------------------|-------------|
-|`filterFields`      |`string`           |`""`                    |A comma separated string that contains the names of the properties to which the filter will be applied.  _(This can be overridden per-table)_|
 |`filterTemplate`    |`string`           |`""`                    |HTML string template for filtering the table. _This will be included **before** the element with `ts-wrapper` specified on it._  See example above.|
 |`filterFunction`    |`function`         |`null`                  |A function that will be called for every item being iterated over in the table. This function will be passed the object being iterated over as the first parameter. It should return a `boolean` value as to include the item or not.  _(This can be overridden per-table)_|
 |`itemNameSingular`  |`string`           |`"item"`                |The default singular version of the name for the items being iterated over. _(This can be overridden per-table)_|

--- a/example-advanced.html
+++ b/example-advanced.html
@@ -140,6 +140,33 @@
                 </tr>
             </tbody>
         </table>
+
+        <hr />
+        
+        <h2>Custom table layout without a header</h2>
+        <table class="table table-striped" ts-wrapper ts-item-name="product" ts-filter-fields="Name">            
+            <tbody>
+                <tr ng-repeat="item in tableOneItems track by item.Id"
+                    ts-repeat>
+                    <td>
+                        <div>
+                            <label>Name</label> <input type="text" class="form-control" ng-model="item.Name" />
+                        </div>                        
+                    </td>
+                    <td>
+                        <div>
+                            <label>Id</label> {{item.Id}}
+                        </div>                        
+                        <div>
+                            <label>Price</label> {{item.Price | currency}}    
+                        </div>
+                        <div>
+                            <label>Qty</label> {{item.Quantity}}
+                        </div>                        
+                    </td>                    
+                </tr>
+            </tbody>
+        </table>
         
     </div>
 </div>

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -146,7 +146,7 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
 
             this.addFilterField = function( sortexpr, element ) {
                 var expr = parse_sortexpr( sortexpr );
-                $scope.filtering.filterFields.push( expr )
+                $scope.filtering.filterFields.push( expr );
             };
 
             this.setDataForPager = function( dataArrayExp ){
@@ -197,12 +197,15 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 }
             }
 			
-			if($attrs.tsFilterFields){
-				var filterFields = $attrs.tsFilterFields.split(",").filter(function(item){return item && item.trim() !== ""});
-				for( var i=0; i<filterFields.length; i=i+1 ){
-					tsWrapperCtrl.addFilterField(filterFields[i]);
-				}
-			}
+            if($attrs.tsFilterFields){
+                var filterFields = $attrs.tsFilterFields.split(",")
+                    .filter(function(item){
+                    	return item && item.trim() !== "";
+                    });
+                for( var i=0; i<filterFields.length; i=i+1 ){
+                    tsWrapperCtrl.addFilterField(filterFields[i]);
+                }
+            }
             
             var $filterHtml;
             if($attrs.tsDisplayFiltering !== "false" && $scope.filtering.template !== "" && $scope.filtering.filterFields.length>0){

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -153,7 +153,7 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 $scope.pagination.itemsArrayExpression = dataArrayExp;
             }
         }],
-        link: function($scope, $element, $attrs){
+        link: function($scope, $element, $attrs, tsWrapperCtrl){
             
             if($attrs.tsItemName){
                 var originalNoDataText = "No " + $scope.itemNamePlural;

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -196,6 +196,13 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                     }
                 }
             }
+			
+			if($attrs.tsFilterFields){
+				var filterFields = $attrs.tsFilterFields.split(",").filter(function(item){return item && item.trim() !== ""});
+				for( var i=0; i<filterFields.length; i=i+1 ){
+					tsWrapperCtrl.addFilterField(filterFields[i]);
+				}
+			}
             
             var $filterHtml;
             if($attrs.tsDisplayFiltering !== "false" && $scope.filtering.template !== "" && $scope.filtering.filterFields.length>0){


### PR DESCRIPTION
Add ability to declare filter fields within the wrapper.  This is useful for tables that do not have a header row.  This can be implemented like this:

```
<table ts-wrapper ts-filter-fields="field1,field2,field3">

    <!-- there are no headers -->

    <tbody> ... </tbody>
</table>
```
